### PR TITLE
Avoid using Pathname to compute relative paths in spout - fix merge regression

### DIFF
--- a/lib/red_storm/dsl/spout.rb
+++ b/lib/red_storm/dsl/spout.rb
@@ -162,7 +162,7 @@ module RedStorm
       # below non-dry see Bolt class
       def self.inherited(subclass)
         path = (caller.first.to_s =~ /^(.+):\d+.*$/) ? $1 : raise(SpoutError, "unable to extract base topology class path from #{caller.first.inspect}")
-        subclass.base_class_path = Pathname.new(path).relative_path_from(Pathname.new(RedStorm::BASE_PATH)).to_s
+        subclass.base_class_path = File.expand_path(path)
       end
 
       def self.base_class_path=(path)

--- a/spec/red_storm/dsl/bolt_spec.rb
+++ b/spec/red_storm/dsl/bolt_spec.rb
@@ -900,5 +900,11 @@ describe RedStorm::SimpleBolt do
       end
     end
 
+    describe 'inherited' do
+      it 'should calculate base class path correctly' do
+        expect(File).to receive(:expand_path).with(__FILE__)
+        class TestBolt < RedStorm::SimpleBolt; end
+      end
+    end
   end
 end

--- a/spec/red_storm/dsl/spout_spec.rb
+++ b/spec/red_storm/dsl/spout_spec.rb
@@ -895,5 +895,12 @@ describe RedStorm::SimpleSpout do
         spout.get_component_configuration.should be_instance_of(Backtype::Config)
       end
     end
+
+    describe 'inherited' do
+      it 'should calculate base class path correctly' do
+        expect(File).to receive(:expand_path).with(__FILE__)
+        class TestSpout < RedStorm::SimpleSpout; end
+      end
+    end
   end
 end


### PR DESCRIPTION
Merge inadvertently changed inherited method to once again use
Pathname to compute relative paths. This change once more allows
the code to work either in a jar context, or a .rb file on
the filesystem.
